### PR TITLE
Upgrade to 3.2.2.GA of remoting and fix compile issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <version.org.jboss.ejb-client>1.0.0.Final</version.org.jboss.ejb-client>
         <version.org.jboss.logmanager>1.2.0.GA</version.org.jboss.logmanager>
         <version.org.jboss.marshalling>1.3.0.GA</version.org.jboss.marshalling>
-        <version.org.jboss.remoting3>3.2.0.CR9</version.org.jboss.remoting3>
+        <version.org.jboss.remoting3>3.2.2.GA</version.org.jboss.remoting3>
         <version.org.jboss.sasl>1.0.0.Final</version.org.jboss.sasl>
         <version.org.jboss.xnio>3.0.0.GA</version.org.jboss.xnio>
     </properties>

--- a/src/main/java/org/jboss/naming/remote/client/cache/ConnectionCache.java
+++ b/src/main/java/org/jboss/naming/remote/client/cache/ConnectionCache.java
@@ -20,6 +20,7 @@ import org.jboss.remoting3.Channel;
 import org.jboss.remoting3.CloseHandler;
 import org.jboss.remoting3.Connection;
 import org.jboss.remoting3.Endpoint;
+import org.jboss.remoting3.security.UserInfo;
 import org.xnio.IoFuture;
 import org.xnio.OptionMap;
 
@@ -89,6 +90,11 @@ public class ConnectionCache {
 
         public Collection<Principal> getPrincipals() {
             return delegate.getPrincipals();
+        }
+
+        @Override
+        public UserInfo getUserInfo() {
+            return delegate.getUserInfo();
         }
 
         public IoFuture<Channel> openChannel(final String s, final OptionMap optionMap) {

--- a/src/test/java/org/jboss/naming/remote/ClientConnectionTest.java
+++ b/src/test/java/org/jboss/naming/remote/ClientConnectionTest.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
+import java.security.Principal;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -52,7 +54,10 @@ import org.jboss.remoting3.Connection;
 import org.jboss.remoting3.Endpoint;
 import org.jboss.remoting3.Remoting;
 import org.jboss.remoting3.remote.RemoteConnectionProviderFactory;
+import org.jboss.remoting3.security.AuthorizingCallbackHandler;
 import org.jboss.remoting3.security.ServerAuthenticationProvider;
+import org.jboss.remoting3.security.SimpleUserInfo;
+import org.jboss.remoting3.security.UserInfo;
 import org.jboss.remoting3.spi.NetworkServerProvider;
 import org.junit.AfterClass;
 import static org.junit.Assert.assertEquals;
@@ -445,13 +450,21 @@ public class ClientConnectionTest {
 
     private static class DefaultAuthenticationHandler implements ServerAuthenticationProvider {
         @Override
-        public CallbackHandler getCallbackHandler(String mechanismName) {
+        public AuthorizingCallbackHandler getCallbackHandler(String mechanismName) {
             if (mechanismName.equals(ANONYMOUS)) {
-                return new CallbackHandler() {
+                return new AuthorizingCallbackHandler() {
                     public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
                         for (Callback current : callbacks) {
                             throw new UnsupportedCallbackException(current, "ANONYMOUS mechanism so not expecting a callback");
                         }
+                    }
+
+                    @Override
+                    public UserInfo createUserInfo(Collection<Principal> remotingPrincipals) throws IOException {
+                        if (remotingPrincipals == null) {
+                            return null;
+                        }
+                        return new SimpleUserInfo(remotingPrincipals);
                     }
                 };
             }


### PR DESCRIPTION
The commit here upgrades jboss-remoting to 3.2.2.GA and fixes the compilation issues.
