### PR TITLE
AS7-3884 Reuse cached channel for a cached connection

### DIFF
--- a/src/main/java/org/jboss/naming/remote/client/cache/ConnectionCache.java
+++ b/src/main/java/org/jboss/naming/remote/client/cache/ConnectionCache.java
@@ -1,5 +1,16 @@
 package org.jboss.naming.remote.client.cache;
 
+import org.jboss.logging.Logger;
+import org.jboss.naming.remote.protocol.IoFutureHelper;
+import org.jboss.remoting3.Attachments;
+import org.jboss.remoting3.Channel;
+import org.jboss.remoting3.CloseHandler;
+import org.jboss.remoting3.Connection;
+import org.jboss.remoting3.Endpoint;
+import org.xnio.IoFuture;
+import org.xnio.OptionMap;
+
+import javax.security.auth.callback.CallbackHandler;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
@@ -11,18 +22,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.security.auth.callback.CallbackHandler;
-
-import org.jboss.logging.Logger;
-import org.jboss.naming.remote.protocol.IoFutureHelper;
-import org.jboss.remoting3.Attachments;
-import org.jboss.remoting3.Channel;
-import org.jboss.remoting3.CloseHandler;
-import org.jboss.remoting3.Connection;
-import org.jboss.remoting3.Endpoint;
-import org.xnio.IoFuture;
-import org.xnio.OptionMap;
-
 /**
  * @author John Bailey
  */
@@ -31,8 +30,20 @@ public class ConnectionCache {
 
     private final ConcurrentMap<CacheKey, CacheEntry> cache = new ConcurrentHashMap<CacheKey, CacheEntry>();
 
+    /**
+     * @param clientEndpoint
+     * @param connectionURI
+     * @param connectOptions
+     * @param callbackHandler
+     * @param connectionTimeout
+     * @return
+     * @throws IOException
+     * @deprecated Since 1.0.2.Final. Use {@link #getChannel(org.jboss.remoting3.Endpoint, java.net.URI, org.xnio.OptionMap, javax.security.auth.callback.CallbackHandler, long, org.xnio.OptionMap, long)}
+     *             instead
+     */
+    @Deprecated
     public synchronized Connection get(final Endpoint clientEndpoint, final URI connectionURI, final OptionMap connectOptions, final CallbackHandler callbackHandler, final long connectionTimeout) throws IOException {
-        final CacheKey key = new CacheKey(callbackHandler.getClass(), connectOptions, connectionURI);
+        final CacheKey key = new CacheKey(clientEndpoint, callbackHandler.getClass(), connectOptions, connectionURI);
         CacheEntry cacheEntry = cache.get(key);
         if (cacheEntry == null) {
             synchronized (this) {
@@ -46,6 +57,43 @@ public class ConnectionCache {
         }
         cacheEntry.referenceCount.incrementAndGet();
         return cacheEntry.connection;
+    }
+
+    /**
+     * Returns a {@link Channel} for the passed connection properties. If the connection is already created
+     * and cached for the passed connection properties, then the cached channel will be returned. Else a new
+     * connection and channel will be created and that new channel returned.
+     *
+     * @param clientEndpoint                 The {@link Endpoint} that will be used to open a connection
+     * @param connectionURI                  The connection URI
+     * @param connectOptions                 The options to be used for connection creation
+     * @param callbackHandler                The callback handler to be used for connection creation
+     * @param connectionTimeout              The connection timeout in milli seconds that will be used while creating a connection
+     * @param channelCreationOptions         The {@link OptionMap options} that will be used if/when the channel is created
+     * @param channelCreationTimeoutInMillis The timeout in milli seconds, that will be used while opening a channel
+     * @return
+     * @throws IOException
+     */
+    public synchronized Channel getChannel(final Endpoint clientEndpoint, final URI connectionURI, final OptionMap connectOptions, final CallbackHandler callbackHandler, final long connectionTimeout,
+                                           final OptionMap channelCreationOptions, final long channelCreationTimeoutInMillis) throws IOException {
+        final CacheKey key = new CacheKey(clientEndpoint, callbackHandler.getClass(), connectOptions, connectionURI);
+        CacheEntry cacheEntry = cache.get(key);
+        if (cacheEntry == null) {
+            synchronized (this) {
+                cacheEntry = cache.get(key);
+                if (cacheEntry == null) {
+                    final IoFuture<Connection> futureConnection = clientEndpoint.connect(connectionURI, connectOptions, callbackHandler);
+                    final Connection connection = IoFutureHelper.get(futureConnection, connectionTimeout, TimeUnit.MILLISECONDS);
+                    // open a channel
+                    final IoFuture<Channel> futureChannel = connection.openChannel("naming", channelCreationOptions);
+                    final Channel channel = IoFutureHelper.get(futureChannel, channelCreationTimeoutInMillis, TimeUnit.MILLISECONDS);
+                    cacheEntry = new CacheEntry(new ConnectionWrapper(key, connection), channel);
+                    cache.put(key, cacheEntry);
+                }
+            }
+        }
+        cacheEntry.referenceCount.incrementAndGet();
+        return cacheEntry.channel;
     }
 
     public void release(final Object connectionHash) {
@@ -73,7 +121,7 @@ public class ConnectionCache {
     }
 
     public synchronized void shutdown() {
-        for(Map.Entry<CacheKey, CacheEntry> entry : cache.entrySet()) {
+        for (Map.Entry<CacheKey, CacheEntry> entry : cache.entrySet()) {
             safeClose(entry.getValue().connection);
         }
     }
@@ -130,30 +178,39 @@ public class ConnectionCache {
 
     private class CacheEntry {
         private final AtomicInteger referenceCount = new AtomicInteger(0);
-        private volatile Connection connection;
+        private final Connection connection;
+        private final Channel channel;
 
-        private CacheEntry(Connection connection) {
+        private CacheEntry(final Connection connection) {
             this.connection = connection;
+            this.channel = null;
+        }
+
+        private CacheEntry(final Connection connection, final Channel channel) {
+            this.connection = connection;
+            this.channel = channel;
         }
     }
 
     private static final class CacheKey {
+        final Endpoint endpoint;
         final URI destination;
         final OptionMap connectOptions;
         final Class<?> callbackHandlerClass;
 
-        private CacheKey(final Class<?> callbackHandlerClass, final OptionMap connectOptions, final URI destination) {
+        private CacheKey(final Endpoint endpoint, final Class<?> callbackHandlerClass, final OptionMap connectOptions, final URI destination) {
+            this.endpoint = endpoint;
             this.callbackHandlerClass = callbackHandlerClass;
             this.connectOptions = connectOptions;
             this.destination = destination;
         }
 
         @Override
-        public boolean equals(final Object o) {
+        public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
 
-            final CacheKey cacheKey = (CacheKey) o;
+            CacheKey cacheKey = (CacheKey) o;
 
             if (callbackHandlerClass != null ? !callbackHandlerClass.equals(cacheKey.callbackHandlerClass) : cacheKey.callbackHandlerClass != null)
                 return false;
@@ -161,13 +218,15 @@ public class ConnectionCache {
                 return false;
             if (destination != null ? !destination.equals(cacheKey.destination) : cacheKey.destination != null)
                 return false;
+            if (endpoint != null ? !endpoint.equals(cacheKey.endpoint) : cacheKey.endpoint != null) return false;
 
             return true;
         }
 
         @Override
         public int hashCode() {
-            int result = destination != null ? destination.hashCode() : 0;
+            int result = endpoint != null ? endpoint.hashCode() : 0;
+            result = 31 * result + (destination != null ? destination.hashCode() : 0);
             result = 31 * result + (connectOptions != null ? connectOptions.hashCode() : 0);
             result = 31 * result + (callbackHandlerClass != null ? callbackHandlerClass.hashCode() : 0);
             return result;


### PR DESCRIPTION
The commit in this branch fixes the issue reported in https://issues.jboss.org/browse/AS7-3884. This commit ensures that we reuse a remoting channel for the cached connections.
