### PR TITLE
AS7-5718. Use the correct classloader when deserializing remote objects

### DIFF
--- a/src/main/java/org/jboss/naming/remote/protocol/v1/ReadUtil.java
+++ b/src/main/java/org/jboss/naming/remote/protocol/v1/ReadUtil.java
@@ -29,6 +29,7 @@ import org.jboss.marshalling.ByteInput;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;
+import org.jboss.marshalling.SimpleClassResolver;
 import org.jboss.marshalling.Unmarshaller;
 import static org.jboss.naming.remote.protocol.v1.Constants.MARSHALLING_STRATEGY;
 
@@ -45,8 +46,8 @@ public class ReadUtil {
         }
     }
 
-    static Unmarshaller prepareForUnMarshalling(final DataInput dataInput) throws IOException {
-        final Unmarshaller unmarshaller = getUnMarshaller(marshallerFactory);
+    static Unmarshaller prepareForUnMarshalling(final DataInput dataInput, final ClassLoader classloader) throws IOException {
+        final Unmarshaller unmarshaller = getUnMarshaller(marshallerFactory, classloader);
         final InputStream is = new InputStream() {
             @Override
             public int read() throws IOException {
@@ -66,9 +67,10 @@ public class ReadUtil {
         return unmarshaller;
     }
 
-    static Unmarshaller getUnMarshaller(final MarshallerFactory marshallerFactory) throws IOException {
+    static Unmarshaller getUnMarshaller(final MarshallerFactory marshallerFactory, final ClassLoader classloader) throws IOException {
         final MarshallingConfiguration marshallingConfiguration = new MarshallingConfiguration();
         marshallingConfiguration.setVersion(2);
+    	marshallingConfiguration.setClassResolver(new SimpleClassResolver(classloader));
         return marshallerFactory.createUnmarshaller(marshallingConfiguration);
     }
 


### PR DESCRIPTION
This patch add a new ClassLoadingNamedIoFuture class which carries the classloader from call to handler for the commands that need it.

The type parameter changes  mean that subclasses of ProtocolIoFuture can be passed to the handle methods in a type-safe way.

All handleServerMessage() implementations use jboss-as-naming's classloader to read the request.

handleClientMessage() implementations which may receive deployment objects (lookup, listBindings and lookupLink) use the TCCL from the call to execute() which should be the one making the Context.*() call

handleClientMessage() implemenations that do not receive deployment objects use  jboss-as-naming's classloader.
