### PR TITLE
Refactor the EJB client integration in the remote naming project to have a more robust and cleaner integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,11 +41,13 @@
     <properties>
         <version.org.jboss.logging.jboss-logging>3.1.0.GA</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-processor>1.0.0.Final</version.org.jboss.logging.jboss-logging-processor>
-        <version.org.jboss.ejb-client>1.0.0.Final</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>1.0.13.Final</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-spec>1.0.2.Final</version.org.jboss.ejb-spec>
         <version.org.jboss.logmanager>1.2.0.GA</version.org.jboss.logmanager>
         <version.org.jboss.marshalling>1.3.0.GA</version.org.jboss.marshalling>
         <version.org.jboss.remoting3>3.2.7.GA</version.org.jboss.remoting3>
         <version.org.jboss.sasl>1.0.0.Final</version.org.jboss.sasl>
+        <version.org.jboss.transaction-spec>1.0.1.Final</version.org.jboss.transaction-spec>
         <version.org.jboss.xnio>3.0.0.GA</version.org.jboss.xnio>
     </properties>
 
@@ -140,6 +142,19 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.8.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+            <version>${version.org.jboss.ejb-spec}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.transaction</groupId>
+            <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+            <version>${version.org.jboss.transaction-spec}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/jboss/naming/remote/client/RemoteContextFactory.java
+++ b/src/main/java/org/jboss/naming/remote/client/RemoteContextFactory.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import org.jboss.logging.Logger;
+import org.jboss.naming.remote.client.ejb.EJBClientHandler;
 import org.jboss.naming.remote.protocol.Versions;
 import org.jboss.remoting3.Channel;
 import org.jboss.remoting3.MessageInputStream;
@@ -48,6 +49,10 @@ class RemoteContextFactory {
     private static final Logger log = Logger.getLogger(RemoteContextFactory.class);
 
     static RemoteNamingStore createVersionedStore(final Channel channel) throws IOException {
+        return createVersionedStore(channel, null);
+    }
+
+    static RemoteNamingStore createVersionedStore(final Channel channel, final EJBClientHandler ejbClientHandler) throws IOException {
         IoFuture<byte[]> futureHeader = ClientVersionReceiver.getVersions(channel);
         IoFuture.Status result = futureHeader.await(5, TimeUnit.SECONDS);
         switch (result) {
@@ -65,7 +70,7 @@ class RemoteContextFactory {
                 highest = current;
             }
         }
-        final RemoteNamingStore store = Versions.getRemoteNamingStore(highest, channel);
+        final RemoteNamingStore store = Versions.getRemoteNamingStore(highest, channel, ejbClientHandler);
         return store;
     }
 

--- a/src/main/java/org/jboss/naming/remote/client/RemoteNamingStore.java
+++ b/src/main/java/org/jboss/naming/remote/client/RemoteNamingStore.java
@@ -46,6 +46,16 @@ public interface RemoteNamingStore {
     Object lookupLink(final Name name) throws NamingException;
     void close() throws NamingException;
     void closeAsync();
+    /**
+     * @deprecated Since 1.0.6.Final
+     */
+    @Deprecated
     void addEjbContext(CurrentEjbClientConnection connection);
+
+    /**
+     * @deprecated Since 1.0.6.Final
+     * @param connection
+     */
+    @Deprecated
     void removeEjbContext(CurrentEjbClientConnection connection);
 }

--- a/src/main/java/org/jboss/naming/remote/client/ejb/EJBClientHandler.java
+++ b/src/main/java/org/jboss/naming/remote/client/ejb/EJBClientHandler.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.naming.remote.client.ejb;
+
+import org.jboss.remoting3.Connection;
+
+/**
+ * A {@link EJBClientHandler} is an abstraction to allows the remote naming APIs to support EJB invocations
+ * without adding a hard dependency on the EJB client project.
+ * <p/>
+ * This {@link EJBClientHandler} interface is expected to have no references to any of the EJB client APIs.
+ * The implementations of this interface can however refer to the EJB client APIs.
+ *
+ * @author Jaikiran Pai
+ */
+public interface EJBClientHandler {
+
+    /**
+     * Associates the passed <code>connection</code> with an appropriate {@link org.jboss.ejb.client.EJBClientContext}.
+     * The passed <code>connection</code> is typically managed by the remote naming APIs
+     *
+     * @param connection The connection to be associated with the EJB client context
+     * @throws Exception
+     */
+    void associate(final Connection connection) throws Exception;
+
+    /**
+     * This method will be invoked by the remote naming lookup protocol after it has received back the object
+     * from the server, during a {@link javax.naming.Context#lookup(String)} or {@link javax.naming.Context#lookup(javax.naming.Name)}
+     * operation. This allows the {@link EJBClientHandler} implementations to check if the returned object is an
+     * {@link org.jboss.ejb.client.EJBClient#isEJBProxy(Object) EJB proxy} and if it is, then do any relevant processing
+     * of that proxy before returning back the processed/updated proxy.
+     * <p/>
+     * If the passed <code>instance</code> is not an EJB proxy then the implementations of this {@link EJBClientHandler}
+     * are expected to just return back the passed <code>instance</code>.
+     *
+     * @param instance The object instance which was returned by the server after a remote naming lookup
+     * @return
+     */
+    Object handleLookupReturnInstance(Object instance);
+}

--- a/src/main/java/org/jboss/naming/remote/client/ejb/RemoteNamingEjbClientContextSelector.java
+++ b/src/main/java/org/jboss/naming/remote/client/ejb/RemoteNamingEjbClientContextSelector.java
@@ -11,7 +11,10 @@ import java.util.IdentityHashMap;
 
 /**
  * @author John Bailey
+ * @deprecated Since 1.0.6.Final - remote-naming no longer switches EJB client context selector for providing
+ *              EJB invocation support. Instead we use {@link EJBClientHandler} to handle EJB integration in remote-naming
  */
+@Deprecated
 public class RemoteNamingEjbClientContextSelector implements ContextSelector<EJBClientContext> {
 
     private ContextSelector<EJBClientContext> delegate;

--- a/src/main/java/org/jboss/naming/remote/client/ejb/RemoteNamingStoreEJBClientHandler.java
+++ b/src/main/java/org/jboss/naming/remote/client/ejb/RemoteNamingStoreEJBClientHandler.java
@@ -1,0 +1,124 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.naming.remote.client.ejb;
+
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClient;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.EJBClientContextIdentifier;
+import org.jboss.ejb.client.EJBLocator;
+import org.jboss.ejb.client.IdentityEJBClientContextSelector;
+import org.jboss.ejb.client.NamedEJBClientContextIdentifier;
+import org.jboss.logging.Logger;
+import org.jboss.naming.remote.client.RemoteContext;
+import org.jboss.remoting3.Connection;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * An implementation of {@link EJBClientHandler} which has hard dependency on the EJB client APIs
+ *
+ * @author Jaikiran Pai
+ */
+public class RemoteNamingStoreEJBClientHandler implements EJBClientHandler {
+
+    private static final Logger logger = Logger.getLogger(RemoteNamingStoreEJBClientHandler.class);
+
+    private static final String EJB_CLIENT_CONTEXT_NAME_PREFIX = "RemoteNamingEJBClientContext$";
+    private static final AtomicLong nextEJBClientContextNumber = new AtomicLong();
+
+    private final EJBClientContextIdentifier ejbClientContextIdentifier;
+    private final EJBClientContext ejbClientContext;
+
+    // This method is referenced via reflection in the org.jboss.naming.remote.client.InitialContextFactory
+    // to avoid any hard dependencies between the core remote naming APIs and the EJB client APIs. That way,
+    // remote naming is still functional even in the absence of EJB client API jars.
+    public static RemoteNamingStoreEJBClientHandler setupEJBClientContext(final List<RemoteContext.CloseTask> closeTasks) {
+        final EJBClientContext ejbClientContext = EJBClientContext.create();
+        final String ejbClientContextName = EJB_CLIENT_CONTEXT_NAME_PREFIX + nextEJBClientContextNumber.addAndGet(1);
+        final EJBClientContextIdentifier ejbClientContextIdentifier = new NamedEJBClientContextIdentifier(ejbClientContextName);
+        // register the context with the selector
+        registerEJBClientContextWithSelector(ejbClientContextIdentifier, ejbClientContext);
+        // add a close task which closes the EJB client context when the remote naming context is closed
+        if (closeTasks != null) {
+            closeTasks.add(new RemoteNamingEJBClientContextCloseTask(ejbClientContext));
+        }
+        return new RemoteNamingStoreEJBClientHandler(ejbClientContextIdentifier, ejbClientContext);
+    }
+
+    private RemoteNamingStoreEJBClientHandler(final EJBClientContextIdentifier ejbClientContextIdentifier, final EJBClientContext ejbClientContext) {
+        this.ejbClientContext = ejbClientContext;
+        this.ejbClientContextIdentifier = ejbClientContextIdentifier;
+    }
+
+    @Override
+    public void associate(final Connection connection) {
+        this.ejbClientContext.registerConnection(connection);
+    }
+
+    @Override
+    public Object handleLookupReturnInstance(Object instance) {
+        if (instance == null) {
+            return null;
+        }
+        if (!EJBClient.isEJBProxy(instance)) {
+            return instance;
+        }
+        final EJBLocator ejbLocator = EJBClient.getLocatorFor(instance);
+        // recreate the proxy by associating it with the EJB client context identifier applicable for this
+        // remote naming context
+        return EJBClient.createProxy(ejbLocator, this.ejbClientContextIdentifier);
+    }
+
+    private static void registerEJBClientContextWithSelector(final EJBClientContextIdentifier identifier, final EJBClientContext ejbClientContext) {
+        final ContextSelector<EJBClientContext> currentSelector = EJBClientContext.getSelector();
+        // if the selector isn't able to handle identity based EJB client contexts, then we don't create one.
+        if (!(currentSelector instanceof IdentityEJBClientContextSelector)) {
+            logger.info("Cannot create a scoped EJB client context for JNDI naming context since the current " +
+                    "EJB client context selector can't handle scoped contexts");
+        } else {
+            // register it with the identity based EJB client context selector
+            ((IdentityEJBClientContextSelector) currentSelector).registerContext(identifier, ejbClientContext);
+        }
+    }
+
+    private static class RemoteNamingEJBClientContextCloseTask implements RemoteContext.CloseTask {
+
+        private EJBClientContext ejbClientContext;
+
+        private RemoteNamingEJBClientContextCloseTask(final EJBClientContext clientContext) {
+            this.ejbClientContext = clientContext;
+        }
+
+        @Override
+        public void close(boolean isFinalize) {
+            try {
+                this.ejbClientContext.close();
+            } catch (IOException e) {
+                logger.debug("Failed to close EJB client context " + this.ejbClientContext, e);
+            }
+        }
+    }
+}

--- a/src/main/java/org/jboss/naming/remote/protocol/Versions.java
+++ b/src/main/java/org/jboss/naming/remote/protocol/Versions.java
@@ -22,6 +22,8 @@
 package org.jboss.naming.remote.protocol;
 
 import java.io.IOException;
+
+import org.jboss.naming.remote.client.ejb.EJBClientHandler;
 import org.jboss.naming.remote.server.RemoteNamingServer;
 import org.jboss.naming.remote.server.RemoteNamingService;
 import org.jboss.naming.remote.client.RemoteNamingStore;
@@ -45,8 +47,12 @@ public class Versions {
     }
 
     public static RemoteNamingStore getRemoteNamingStore(final byte version, final Channel channel) throws IOException {
+        return  getRemoteNamingStore(version, channel, null);
+    }
+
+    public static RemoteNamingStore getRemoteNamingStore(final byte version, final Channel channel, final EJBClientHandler ejbClientHandler) throws IOException {
         if (version == VersionOne.getVersionIdentifier()) {
-            return VersionOne.getRemoteNamingStore(channel);
+            return VersionOne.getRemoteNamingStore(channel, ejbClientHandler);
         }
 
         throw new IllegalArgumentException("Unsupported protocol version [" + version + "]");

--- a/src/main/java/org/jboss/naming/remote/protocol/v1/VersionOne.java
+++ b/src/main/java/org/jboss/naming/remote/protocol/v1/VersionOne.java
@@ -22,6 +22,8 @@
 package org.jboss.naming.remote.protocol.v1;
 
 import java.io.IOException;
+
+import org.jboss.naming.remote.client.ejb.EJBClientHandler;
 import org.jboss.naming.remote.server.RemoteNamingServer;
 import org.jboss.naming.remote.server.RemoteNamingService;
 import org.jboss.remoting3.Channel;
@@ -41,10 +43,15 @@ public class VersionOne {
     }
 
     public static RemoteNamingStoreV1 getRemoteNamingStore(final Channel channel) throws IOException {
-        final RemoteNamingStoreV1 context = new RemoteNamingStoreV1(channel);
+        return getRemoteNamingStore(channel, null);
+    }
+
+    public static RemoteNamingStoreV1 getRemoteNamingStore(final Channel channel, final EJBClientHandler ejbClientHandler) throws IOException {
+        final RemoteNamingStoreV1 context = new RemoteNamingStoreV1(channel, ejbClientHandler);
         context.start();
         return context;
     }
+
 
     public static RemoteNamingServer getNamingServer(final Channel channel, final RemoteNamingService remoteNamingServer) {
         final RemoteNamingServerV1 server = new RemoteNamingServerV1(channel, remoteNamingServer);

--- a/src/test/java/org/jboss/naming/remote/ClientConnectionTest.java
+++ b/src/test/java/org/jboss/naming/remote/ClientConnectionTest.java
@@ -21,28 +21,8 @@
  */
 package org.jboss.naming.remote;
 
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-
-import javax.naming.Binding;
-import javax.naming.Context;
-import javax.naming.InitialContext;
-import javax.naming.LinkRef;
-import javax.naming.NameClassPair;
-import javax.naming.NameNotFoundException;
-import javax.naming.NamingEnumeration;
-
-import org.jboss.ejb.client.ContextSelector;
-import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.naming.remote.client.InitialContextFactory;
 import org.jboss.naming.remote.client.RemoteContext;
-import org.jboss.naming.remote.client.ejb.RemoteNamingEjbClientContextSelector;
 import org.jboss.naming.remote.protocol.IoFutureHelper;
 import org.jboss.naming.remote.server.RemoteNamingService;
 import org.jboss.remoting3.Connection;
@@ -57,6 +37,22 @@ import org.xnio.IoFuture;
 import org.xnio.OptionMap;
 import org.xnio.Options;
 import org.xnio.Xnio;
+
+import javax.naming.Binding;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.LinkRef;
+import javax.naming.NameClassPair;
+import javax.naming.NameNotFoundException;
+import javax.naming.NamingEnumeration;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -396,36 +392,5 @@ public class ClientConnectionTest {
         localContext.unbind("test");
 
         endpoint.close();
-    }
-
-    @Test
-    public void testSetupEjb() throws Exception {
-        final Xnio xnio = Xnio.getInstance();
-        final Endpoint endpoint = Remoting.createEndpoint("RemoteNaming", xnio, OptionMap.EMPTY);
-        endpoint.addConnectionProvider("remote", new RemoteConnectionProviderFactory(), OptionMap.create(SSL_ENABLED, false));
-
-        final IoFuture<Connection> futureConnection = endpoint.connect(new URI("remote://localhost:7999"), OptionMap.create(Options.SASL_POLICY_NOANONYMOUS, false), new TestUtils.AnonymousCallbackHandler());
-        final Connection connection = IoFutureHelper.get(futureConnection, 1000, TimeUnit.MILLISECONDS);
-
-        final ContextSelector<EJBClientContext> temp = new MockSelector();
-
-        final ContextSelector<EJBClientContext> original = EJBClientContext.setSelector(temp);
-
-        final Properties env = new Properties();
-        env.put(Context.INITIAL_CONTEXT_FACTORY, org.jboss.naming.remote.client.InitialContextFactory.class.getName());
-        env.put(InitialContextFactory.CONNECTION, connection);
-        env.put(InitialContextFactory.SETUP_EJB_CONTEXT, true);
-        final Context context = new InitialContext(env);
-
-        final ContextSelector<EJBClientContext> newSelector = EJBClientContext.setSelector(new MockSelector());
-        assertTrue(newSelector instanceof RemoteNamingEjbClientContextSelector);
-        context.close();
-    }
-
-
-    private class MockSelector implements ContextSelector<EJBClientContext> {
-        public EJBClientContext getCurrent() {
-            return null;
-        }
     }
 }

--- a/src/test/java/org/jboss/naming/remote/common/ejb/DummyEJBServer.java
+++ b/src/test/java/org/jboss/naming/remote/common/ejb/DummyEJBServer.java
@@ -1,0 +1,528 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.naming.remote.common.ejb;
+
+import org.jboss.ejb.client.ClusterAffinity;
+import org.jboss.ejb.client.SessionID;
+import org.jboss.ejb.client.remoting.PackedInteger;
+import org.jboss.logging.Logger;
+import org.jboss.marshalling.Marshalling;
+import org.jboss.marshalling.SimpleDataInput;
+import org.jboss.remoting3.Channel;
+import org.jboss.remoting3.CloseHandler;
+import org.jboss.remoting3.Endpoint;
+import org.jboss.remoting3.MessageInputStream;
+import org.jboss.remoting3.OpenListener;
+import org.jboss.remoting3.Registration;
+import org.xnio.IoUtils;
+import org.xnio.OptionMap;
+import org.xnio.channels.AcceptingChannel;
+import org.xnio.channels.ConnectedStreamChannel;
+
+import javax.ejb.NoSuchEJBException;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Future;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class DummyEJBServer {
+
+    private static final Logger logger = Logger.getLogger(DummyEJBServer.class);
+
+    private static final String[] supportedMarshallerTypes = new String[]{"river", "java-serial"};
+    private static final String CLUSTER_NAME = "dummy-cluster";
+
+    private AcceptingChannel<? extends ConnectedStreamChannel> server;
+    private Map<EJBModuleIdentifier, Map<String, Object>> registeredEJBs = new ConcurrentHashMap<EJBModuleIdentifier, Map<String, Object>>();
+
+    private final Collection<Channel> openChannels = new CopyOnWriteArraySet<Channel>();
+
+    private final Endpoint endpoint;
+    private volatile Registration ejbChannelRegistration;
+
+    public DummyEJBServer(final Endpoint endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public synchronized void start() throws IOException {
+        if (this.ejbChannelRegistration != null) {
+            throw new IllegalStateException(this.getClass().getSimpleName() + " is already started");
+        }
+        this.ejbChannelRegistration = this.registerEJBServer();
+    }
+
+    public synchronized void stop() throws IOException {
+        if (this.ejbChannelRegistration == null) {
+            throw new IllegalStateException(this.getClass().getSimpleName() + " is not started");
+        }
+        this.ejbChannelRegistration.close();
+    }
+
+    private Registration registerEJBServer() throws IOException {
+        logger.info("Registering EJB server to endpoint " + endpoint);
+        return endpoint.registerService("jboss.ejb", new OpenListener() {
+            @Override
+            public void channelOpened(Channel channel) {
+                logger.info("Channel opened " + channel);
+                channel.addCloseHandler(new CloseHandler<Channel>() {
+                    @Override
+                    public void handleClose(Channel closed, IOException exception) {
+                        logger.info("Bye " + closed);
+                    }
+                });
+                try {
+                    this.sendVersionMessage(channel);
+                } catch (IOException e) {
+                    logger.error("Could not send version message to channel " + channel + " Closing the channel");
+                    IoUtils.safeClose(channel);
+                }
+                Channel.Receiver handler = new VersionReceiver();
+                channel.receiveMessage(handler);
+            }
+
+            @Override
+            public void registrationTerminated() {
+                logger.info("Registration terminated for open listener");
+            }
+
+            private void sendVersionMessage(final Channel channel) throws IOException {
+                final DataOutputStream outputStream = new DataOutputStream(channel.writeMessage());
+                // write the version
+                outputStream.write(0x01);
+                // write the marshaller type count
+                PackedInteger.writePackedInteger(outputStream, supportedMarshallerTypes.length);
+                // write the marshaller types
+                for (int i = 0; i < supportedMarshallerTypes.length; i++) {
+                    outputStream.writeUTF(supportedMarshallerTypes[i]);
+                }
+                outputStream.flush();
+                outputStream.close();
+            }
+
+        }, OptionMap.EMPTY);
+    }
+
+    public String getClusterName() {
+        return this.CLUSTER_NAME;
+    }
+
+
+    class Version1Receiver implements Channel.Receiver {
+
+        private final DummyProtocolHandler dummyProtocolHandler;
+
+        Version1Receiver(final String marshallingType) {
+            this.dummyProtocolHandler = new DummyProtocolHandler(marshallingType);
+        }
+
+        @Override
+        public void handleError(Channel channel, IOException error) {
+            //To change body of implemented methods use File | Settings | File Templates.
+        }
+
+        @Override
+        public void handleEnd(Channel channel) {
+            //To change body of implemented methods use File | Settings | File Templates.
+        }
+
+        @Override
+        public void handleMessage(Channel channel, MessageInputStream messageInputStream) {
+            final DataInputStream inputStream = new DataInputStream(messageInputStream);
+            try {
+                final byte header = inputStream.readByte();
+                logger.info("Received message with header 0x" + Integer.toHexString(header));
+                switch (header) {
+                    case 0x03:
+                        final MethodInvocationRequest methodInvocationRequest = this.dummyProtocolHandler.readMethodInvocationRequest(inputStream, this.getClass().getClassLoader());
+                        Object methodInvocationResult = null;
+                        try {
+                            methodInvocationResult = DummyEJBServer.this.handleMethodInvocationRequest(channel, methodInvocationRequest, dummyProtocolHandler);
+                        } catch (NoSuchEJBException nsee) {
+                            final DataOutputStream outputStream = new DataOutputStream(channel.writeMessage());
+                            try {
+                                this.dummyProtocolHandler.writeNoSuchEJBFailureMessage(outputStream, methodInvocationRequest.getInvocationId(), methodInvocationRequest.getAppName(),
+                                        methodInvocationRequest.getModuleName(), methodInvocationRequest.getDistinctName(), methodInvocationRequest.getBeanName(),
+                                        methodInvocationRequest.getViewClassName());
+                            } finally {
+                                outputStream.close();
+                            }
+                            return;
+                        } catch (Exception e) {
+                            final DataOutputStream outputStream = new DataOutputStream(channel.writeMessage());
+                            try {
+                                this.dummyProtocolHandler.writeException(outputStream, methodInvocationRequest.getInvocationId(), e, methodInvocationRequest.getAttachments());
+                            } finally {
+                                outputStream.close();
+                            }
+                            return;
+                        }
+                        logger.info("Method invocation result on server " + methodInvocationResult);
+                        // write the method invocation result
+                        final DataOutputStream outputStream = new DataOutputStream(channel.writeMessage());
+                        try {
+                            this.dummyProtocolHandler.writeMethodInvocationResponse(outputStream, methodInvocationRequest.getInvocationId(), methodInvocationResult, methodInvocationRequest.getAttachments());
+                        } finally {
+                            outputStream.close();
+                        }
+
+                        break;
+                    case 0x01:
+                        // session open request
+                        try {
+                            this.handleSessionOpenRequest(channel, messageInputStream);
+                        } catch (Exception e) {
+                            // TODO: Let the client know of this exception
+                            throw new RuntimeException(e);
+                        }
+
+                        break;
+                    default:
+                        logger.warn("Not supported message header 0x" + Integer.toHexString(header) + " received by " + this);
+                        return;
+                }
+
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            } finally {
+                // receive next message
+                channel.receiveMessage(this);
+                IoUtils.safeClose(inputStream);
+            }
+
+        }
+
+        private void handleSessionOpenRequest(Channel channel, MessageInputStream messageInputStream) throws IOException {
+            if (messageInputStream == null) {
+                throw new IllegalArgumentException("Cannot read from null message inputstream");
+            }
+            final DataInputStream dataInputStream = new DataInputStream(messageInputStream);
+
+            // read invocation id
+            final short invocationId = dataInputStream.readShort();
+            final String appName = dataInputStream.readUTF();
+            final String moduleName = dataInputStream.readUTF();
+            final String distinctName = dataInputStream.readUTF();
+            final String beanName = dataInputStream.readUTF();
+
+            final EJBModuleIdentifier ejbModuleIdentifier = new EJBModuleIdentifier(appName, moduleName, distinctName);
+            final Map<String, Object> ejbs = DummyEJBServer.this.registeredEJBs.get(ejbModuleIdentifier);
+            if (ejbs == null || ejbs.get(beanName) == null) {
+                final DataOutputStream outputStream = new DataOutputStream(channel.writeMessage());
+                try {
+                    this.dummyProtocolHandler.writeNoSuchEJBFailureMessage(outputStream, invocationId, appName, moduleName, distinctName, beanName, null);
+                } finally {
+                    outputStream.close();
+                }
+                return;
+            }
+            final UUID uuid = UUID.randomUUID();
+            ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+            bb.putLong(uuid.getMostSignificantBits());
+            bb.putLong(uuid.getLeastSignificantBits());
+            final SessionID sessionID = SessionID.createSessionID(bb.array());
+            final DataOutputStream outputStream = new DataOutputStream(channel.writeMessage());
+            try {
+                final ClusterAffinity hardAffinity = new ClusterAffinity(DummyEJBServer.this.CLUSTER_NAME);
+                this.dummyProtocolHandler.writeSessionId(outputStream, invocationId, sessionID, hardAffinity);
+            } finally {
+                outputStream.close();
+            }
+        }
+
+
+    }
+
+    public void register(final String appName, final String moduleName, final String distinctName, final String beanName, final Object instance) {
+
+        final EJBModuleIdentifier moduleID = new EJBModuleIdentifier(appName, moduleName, distinctName);
+        Map<String, Object> ejbs = this.registeredEJBs.get(moduleID);
+        if (ejbs == null) {
+            ejbs = new HashMap<String, Object>();
+            this.registeredEJBs.put(moduleID, ejbs);
+        }
+        ejbs.put(beanName, instance);
+        try {
+            this.sendNewModuleReportToClients(new EJBModuleIdentifier[]{moduleID}, true);
+        } catch (IOException e) {
+            logger.warn("Could not send EJB module availability message to clients, for module " + moduleID, e);
+        }
+    }
+
+    public void unregister(final String appName, final String moduleName, final String distinctName, final String beanName) {
+        this.unregister(appName, moduleName, distinctName, beanName, true);
+    }
+
+    public void unregister(final String appName, final String moduleName, final String distinctName, final String beanName, final boolean notifyClients) {
+
+        final EJBModuleIdentifier moduleID = new EJBModuleIdentifier(appName, moduleName, distinctName);
+        Map<String, Object> ejbs = this.registeredEJBs.get(moduleID);
+        if (ejbs != null) {
+            ejbs.remove(beanName);
+        }
+        if (notifyClients) {
+            try {
+                this.sendNewModuleReportToClients(new EJBModuleIdentifier[]{moduleID}, false);
+            } catch (IOException e) {
+                logger.warn("Could not send EJB module un-availability message to clients, for module " + moduleID, e);
+            }
+        }
+    }
+
+
+    private void sendNewModuleReportToClients(final EJBModuleIdentifier[] modules, final boolean availabilityReport) throws IOException {
+        if (modules == null) {
+            return;
+        }
+        if (this.openChannels.isEmpty()) {
+            logger.debug("No open channels to send EJB module availability");
+        }
+        for (final Channel channel : this.openChannels) {
+            final DataOutputStream dataOutputStream = new DataOutputStream(channel.writeMessage());
+            try {
+                if (availabilityReport) {
+                    this.writeModuleAvailability(dataOutputStream, modules);
+                } else {
+                    this.writeModuleUnAvailability(dataOutputStream, modules);
+                }
+            } catch (IOException e) {
+                logger.warn("Could not send module availability message to client", e);
+            } finally {
+                dataOutputStream.close();
+            }
+
+        }
+    }
+
+    private void writeModuleAvailability(final DataOutput output, final EJBModuleIdentifier[] ejbModuleIdentifiers) throws IOException {
+        if (output == null) {
+            throw new IllegalArgumentException("Cannot write to null output");
+        }
+        if (ejbModuleIdentifiers == null) {
+            throw new IllegalArgumentException("EJB module identifiers cannot be null");
+        }
+        // write the header
+        output.write(0x08);
+        this.writeModuleReport(output, ejbModuleIdentifiers);
+    }
+
+    private void writeModuleUnAvailability(final DataOutput output, final EJBModuleIdentifier[] ejbModuleIdentifiers) throws IOException {
+        if (output == null) {
+            throw new IllegalArgumentException("Cannot write to null output");
+        }
+        if (ejbModuleIdentifiers == null) {
+            throw new IllegalArgumentException("EJB module identifiers cannot be null");
+        }
+        // write the header
+        output.write(0x09);
+        this.writeModuleReport(output, ejbModuleIdentifiers);
+    }
+
+    private void writeModuleReport(final DataOutput output, final EJBModuleIdentifier[] modules) throws IOException {
+        // write the count
+        PackedInteger.writePackedInteger(output, modules.length);
+        // write the module identifiers
+        for (int i = 0; i < modules.length; i++) {
+            // write the app name
+            final String appName = modules[i].getAppName();
+            if (appName == null) {
+                // write out a empty string
+                output.writeUTF("");
+            } else {
+                output.writeUTF(appName);
+            }
+            // write the module name
+            output.writeUTF(modules[i].getModuleName());
+            // write the distinct name
+            final String distinctName = modules[i].getDistinctName();
+            if (distinctName == null) {
+                // write out an empty string
+                output.writeUTF("");
+            } else {
+                output.writeUTF(distinctName);
+            }
+        }
+    }
+
+    private Object handleMethodInvocationRequest(final Channel channel, final MethodInvocationRequest methodInvocationRequest, final DummyProtocolHandler dummyProtocolHandler) throws InvocationTargetException, IllegalAccessException, IOException {
+        final EJBModuleIdentifier ejbModuleIdentifier = new EJBModuleIdentifier(methodInvocationRequest.getAppName(), methodInvocationRequest.getModuleName(), methodInvocationRequest.getDistinctName());
+        final Map<String, Object> ejbs = this.registeredEJBs.get(ejbModuleIdentifier);
+        final Object beanInstance = ejbs.get(methodInvocationRequest.getBeanName());
+        if (beanInstance == null) {
+            throw new NoSuchEJBException(methodInvocationRequest.getBeanName() + " EJB not available");
+        }
+        Method method = null;
+        try {
+            method = this.getRequiredMethod(beanInstance.getClass(), methodInvocationRequest.getMethodName(), methodInvocationRequest.getParamTypes());
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+        // check if this is an async method
+        if (this.isAsyncMethod(method)) {
+            final DataOutputStream output = new DataOutputStream(channel.writeMessage());
+            try {
+                // send a notification to the client that this is an async method
+                dummyProtocolHandler.writeAsyncMethodNotification(output, methodInvocationRequest.getInvocationId());
+            } finally {
+                output.close();
+            }
+        }
+        // invoke on the method
+        return method.invoke(beanInstance, methodInvocationRequest.getParams());
+    }
+
+    private Method getRequiredMethod(final Class<?> klass, final String methodName, final String[] paramTypes) throws NoSuchMethodException {
+        final Class<?>[] types = new Class<?>[paramTypes.length];
+        for (int i = 0; i < paramTypes.length; i++) {
+            try {
+                types[i] = Class.forName(paramTypes[i], false, klass.getClassLoader());
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return klass.getMethod(methodName, types);
+    }
+
+    private boolean isAsyncMethod(final Method method) {
+        // just check for return type and assume it to be async if it returns Future
+        return method.getReturnType().equals(Future.class);
+    }
+
+    class VersionReceiver implements Channel.Receiver {
+        @Override
+        public void handleError(Channel channel, IOException error) {
+            try {
+                channel.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            throw new RuntimeException("NYI: .handleError");
+        }
+
+        @Override
+        public void handleEnd(Channel channel) {
+            try {
+                channel.close();
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+
+
+        @Override
+        public void handleMessage(Channel channel, MessageInputStream message) {
+            final SimpleDataInput input = new SimpleDataInput(Marshalling.createByteInput(message));
+            try {
+                final byte version = input.readByte();
+                final String clientMarshallingType = input.readUTF();
+                input.close();
+                switch (version) {
+                    case 0x01:
+                        final Version1Receiver receiver = new Version1Receiver(clientMarshallingType);
+                        DummyEJBServer.this.openChannels.add(channel);
+                        channel.receiveMessage(receiver);
+                        // send module availability report to clients
+                        final Collection<EJBModuleIdentifier> availableModules = DummyEJBServer.this.registeredEJBs.keySet();
+                        DummyEJBServer.this.sendNewModuleReportToClients(availableModules.toArray(new EJBModuleIdentifier[availableModules.size()]), true);
+                        break;
+                    default:
+                        logger.info("Received unsupported version 0x" + Integer.toHexString(version) + " from client, on channel " + channel);
+                        channel.close();
+                        break;
+                }
+            } catch (IOException e) {
+                logger.error("Exception on channel " + channel, e);
+                try {
+                    logger.info("Shutting down channel " + channel);
+                    channel.writeShutdown();
+                } catch (IOException e1) {
+                    // ignore
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Ignoring exception that occurred during channel shutdown", e1);
+                    }
+                }
+            }
+        }
+    }
+
+
+    private class EJBModuleIdentifier {
+        private final String appName;
+
+        private final String moduleName;
+
+        private final String distinctName;
+
+        EJBModuleIdentifier(final String appname, final String moduleName, final String distinctName) {
+            this.appName = appname;
+            this.moduleName = moduleName;
+            this.distinctName = distinctName;
+        }
+
+        String getAppName() {
+            return this.appName;
+        }
+
+        String getModuleName() {
+            return this.moduleName;
+        }
+
+        String getDistinctName() {
+            return this.distinctName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            EJBModuleIdentifier that = (EJBModuleIdentifier) o;
+
+            if (appName != null ? !appName.equals(that.appName) : that.appName != null) return false;
+            if (distinctName != null ? !distinctName.equals(that.distinctName) : that.distinctName != null)
+                return false;
+            if (!moduleName.equals(that.moduleName)) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = appName != null ? appName.hashCode() : 0;
+            result = 31 * result + moduleName.hashCode();
+            result = 31 * result + (distinctName != null ? distinctName.hashCode() : 0);
+            return result;
+        }
+    }
+}

--- a/src/test/java/org/jboss/naming/remote/common/ejb/DummyProtocolHandler.java
+++ b/src/test/java/org/jboss/naming/remote/common/ejb/DummyProtocolHandler.java
@@ -1,0 +1,339 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.naming.remote.common.ejb;
+
+import org.jboss.ejb.client.Affinity;
+import org.jboss.ejb.client.EJBLocator;
+import org.jboss.ejb.client.SessionID;
+import org.jboss.ejb.client.remoting.PackedInteger;
+import org.jboss.ejb.client.remoting.ProtocolV1ClassTable;
+import org.jboss.ejb.client.remoting.ProtocolV1ObjectTable;
+import org.jboss.marshalling.AbstractClassResolver;
+import org.jboss.marshalling.ByteInput;
+import org.jboss.marshalling.ByteOutput;
+import org.jboss.marshalling.Marshaller;
+import org.jboss.marshalling.MarshallerFactory;
+import org.jboss.marshalling.Marshalling;
+import org.jboss.marshalling.MarshallingConfiguration;
+import org.jboss.marshalling.Unmarshaller;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class DummyProtocolHandler {
+
+
+    private static final char METHOD_PARAM_TYPE_SEPARATOR = ',';
+
+    private final MarshallerFactory marshallerFactory;
+
+    private static final byte HEADER_SESSION_OPEN_RESPONSE = 0x02;
+    private static final byte HEADER_INVOCATION_REQUEST = 0x03;
+    private static final byte HEADER_INVOCATION_CANCEL_REQUEST = 0x04;
+    private static final byte HEADER_INVOCATION_RESPONSE = 0x05;
+    private static final byte HEADER_MODULE_AVAILABLE = 0x08;
+    private static final byte HEADER_MODULE_UNAVAILABLE = 0x09;
+    private static final byte HEADER_NO_SUCH_EJB_FAILURE = 0x0A;
+    private static final byte HEADER_INVOCATION_EXCEPTION = 0x06;
+    private static final byte HEADER_ASYNC_METHOD_NOTIFICATION = 0x0E;
+
+    public DummyProtocolHandler(final String marshallerType) {
+        this.marshallerFactory = Marshalling.getProvidedMarshallerFactory(marshallerType);
+        if (this.marshallerFactory == null) {
+            throw new RuntimeException("Could not find a marshaller factory for " + marshallerType + " marshalling strategy");
+        }
+    }
+
+    public MethodInvocationRequest readMethodInvocationRequest(final DataInput input, final ClassLoader cl) throws IOException {
+        // read the invocation id
+        final short invocationId = input.readShort();
+        final String methodName = input.readUTF();
+        // method signature
+        String[] methodParamTypes = null;
+        final String signature = input.readUTF();
+        if (signature.isEmpty()) {
+            methodParamTypes = new String[0];
+        } else {
+            methodParamTypes = signature.split(String.valueOf(METHOD_PARAM_TYPE_SEPARATOR));
+        }
+
+        // unmarshall the locator and the method params
+        final Object[] methodParams = new Object[methodParamTypes.length];
+        final Unmarshaller unmarshaller = this.prepareForUnMarshalling(input);
+        String appName = null;
+        String moduleName = null;
+        String distinctName = null;
+        String beanName = null;
+        EJBLocator ejbLocator = null;
+        try {
+            appName = (String) unmarshaller.readObject();
+            moduleName = (String) unmarshaller.readObject();
+            distinctName = (String) unmarshaller.readObject();
+            beanName = (String) unmarshaller.readObject();
+            ejbLocator = (EJBLocator) unmarshaller.readObject();
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+        for (int i = 0; i < methodParamTypes.length; i++) {
+            try {
+                methodParams[i] = unmarshaller.readObject();
+            } catch (ClassNotFoundException cnfe) {
+                throw new RuntimeException(cnfe);
+            }
+        }
+        // unmarshall the attachments
+        final Map<String, Object> attachments;
+        try {
+            attachments = this.readAttachments(unmarshaller);
+        } catch (ClassNotFoundException cnfe) {
+            throw new RuntimeException(cnfe);
+        }
+
+        unmarshaller.finish();
+
+        return new MethodInvocationRequest(invocationId, appName, moduleName, distinctName, beanName,
+                ejbLocator.getViewType().getName(), methodName, methodParamTypes, methodParams, attachments);
+    }
+
+    public void writeMethodInvocationResponse(final DataOutput output, final short invocationId, final Object result,
+                                              final Map<String, Object> attachments) throws IOException {
+        if (output == null) {
+            throw new IllegalArgumentException("Cannot write to null output");
+        }
+
+        // write invocation response header
+        output.write(HEADER_INVOCATION_RESPONSE);
+        // write the invocation id
+        output.writeShort(invocationId);
+        // write out the result
+        final Marshaller marshaller = this.prepareForMarshalling(output);
+        marshaller.writeObject(result);
+        // write the attachments
+        this.writeAttachments(marshaller, attachments);
+        marshaller.finish();
+    }
+
+    public void writeException(final DataOutput output, final short invocationId, final Throwable t,
+                               final Map<String, Object> attachments) throws IOException {
+        // write the header
+        output.write(HEADER_INVOCATION_EXCEPTION);
+        // write the invocation id
+        output.writeShort(invocationId);
+        // write out the exception
+        final Marshaller marshaller = this.prepareForMarshalling(output);
+        marshaller.writeObject(t);
+        // write the attachments
+        this.writeAttachments(marshaller, attachments);
+        // finish marshalling
+        marshaller.finish();
+    }
+
+    private void writeInvocationFailure(final DataOutput output, final byte messageHeader, final short invocationId, final String failureMessage) throws IOException {
+        // write header
+        output.writeByte(messageHeader);
+        // write invocation id
+        output.writeShort(invocationId);
+        // write the failure message
+        output.writeUTF(failureMessage);
+    }
+
+    public void writeNoSuchEJBFailureMessage(final DataOutput output, final short invocationId, final String appName, final String moduleName,
+                                             final String distinctName, final String beanName, final String viewClassName) throws IOException {
+
+        final StringBuffer sb = new StringBuffer("No such EJB[");
+        sb.append("appname=").append(appName).append(",");
+        sb.append("modulename=").append(moduleName).append(",");
+        sb.append("distinctname=").append(distinctName).append(",");
+        sb.append("beanname=").append(beanName);
+        if (viewClassName != null) {
+            sb.append(",").append("viewclassname=").append(viewClassName);
+        }
+        sb.append("]");
+        this.writeInvocationFailure(output, HEADER_NO_SUCH_EJB_FAILURE, invocationId, sb.toString());
+    }
+
+    public void writeSessionId(final DataOutput output, final short invocationId, final SessionID sessionID, final Affinity hardAffinity) throws IOException {
+        final byte[] sessionIdBytes = sessionID.getEncodedForm();
+        // write out header
+        output.writeByte(HEADER_SESSION_OPEN_RESPONSE);
+        // write out invocation id
+        output.writeShort(invocationId);
+        // session id byte length
+        PackedInteger.writePackedInteger(output, sessionIdBytes.length);
+        // write out the session id bytes
+        output.write(sessionIdBytes);
+        // now marshal the hard affinity associated with this session
+        final Marshaller marshaller = this.prepareForMarshalling(output);
+        marshaller.writeObject(hardAffinity);
+
+        // finish marshalling
+        marshaller.finish();
+    }
+
+    public void writeAsyncMethodNotification(final DataOutput output, final short invocationId) throws IOException {
+        // write the header
+        output.write(HEADER_ASYNC_METHOD_NOTIFICATION);
+        // write the invocation id
+        output.writeShort(invocationId);
+    }
+
+    private Map<String, Object> readAttachments(final ObjectInput input) throws IOException, ClassNotFoundException {
+        final int numAttachments = input.readByte();
+        if (numAttachments == 0) {
+            return null;
+        }
+        final Map<String, Object> attachments = new HashMap<String, Object>(numAttachments);
+        for (int i = 0; i < numAttachments; i++) {
+            // read the key
+            final String key = (String) input.readObject();
+            // read the attachment value
+            final Object val = input.readObject();
+            attachments.put(key, val);
+        }
+        return attachments;
+    }
+
+    private void writeAttachments(final ObjectOutput output, final Map<String, Object> attachments) throws IOException {
+        if (attachments == null) {
+            output.writeByte(0);
+            return;
+        }
+        // write the attachment count
+        PackedInteger.writePackedInteger(output, attachments.size());
+        for (Map.Entry<String, Object> entry : attachments.entrySet()) {
+            output.writeObject(entry.getKey());
+            output.writeObject(entry.getValue());
+        }
+    }
+
+    /**
+     * Creates and returns a {@link org.jboss.marshalling.Marshaller} which is ready to be used for marshalling. The {@link org.jboss.marshalling.Marshaller#start(org.jboss.marshalling.ByteOutput)}
+     * will be invoked by this method, to use the passed {@link java.io.DataOutput dataOutput}, before returning the marshaller.
+     *
+     * @param dataOutput The {@link java.io.DataOutput} to which the data will be marshalled
+     * @return
+     * @throws java.io.IOException
+     */
+    private Marshaller prepareForMarshalling(final DataOutput dataOutput) throws IOException {
+        final Marshaller marshaller = this.getMarshaller();
+        final OutputStream outputStream = new OutputStream() {
+            @Override
+            public void write(int b) throws IOException {
+                final int byteToWrite = b & 0xff;
+                dataOutput.write(byteToWrite);
+            }
+        };
+        final ByteOutput byteOutput = Marshalling.createByteOutput(outputStream);
+        // start the marshaller
+        marshaller.start(byteOutput);
+
+        return marshaller;
+    }
+
+    /**
+     * Creates and returns a {@link org.jboss.marshalling.Marshaller}
+     *
+     * @return
+     * @throws java.io.IOException
+     */
+    private Marshaller getMarshaller() throws IOException {
+        final MarshallingConfiguration marshallingConfiguration = new MarshallingConfiguration();
+        marshallingConfiguration.setClassTable(ProtocolV1ClassTable.INSTANCE);
+        marshallingConfiguration.setObjectTable(ProtocolV1ObjectTable.INSTANCE);
+        marshallingConfiguration.setVersion(2);
+
+        return marshallerFactory.createMarshaller(marshallingConfiguration);
+    }
+
+    /**
+     * Creates and returns a {@link org.jboss.marshalling.Unmarshaller} which is ready to be used for unmarshalling. The {@link org.jboss.marshalling.Unmarshaller#start(org.jboss.marshalling.ByteInput)}
+     * will be invoked by this method, to use the passed {@link java.io.DataInput dataInput}, before returning the unmarshaller.
+     *
+     * @param dataInput The data input from which to unmarshall
+     * @return
+     * @throws java.io.IOException
+     */
+    private Unmarshaller prepareForUnMarshalling(final DataInput dataInput) throws IOException {
+        final Unmarshaller unmarshaller = this.getUnMarshaller();
+        final InputStream is = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                try {
+
+                    final int b = dataInput.readByte();
+                    return b & 0xff;
+                } catch (EOFException eof) {
+                    return -1;
+                }
+            }
+        };
+        final ByteInput byteInput = Marshalling.createByteInput(is);
+        // start the unmarshaller
+        unmarshaller.start(byteInput);
+
+        return unmarshaller;
+    }
+
+    /**
+     * Creates and returns a {@link org.jboss.marshalling.Unmarshaller}
+     *
+     * @return
+     * @throws java.io.IOException
+     */
+    private Unmarshaller getUnMarshaller() throws IOException {
+        final MarshallingConfiguration marshallingConfiguration = new MarshallingConfiguration();
+        marshallingConfiguration.setVersion(2);
+        marshallingConfiguration.setClassTable(ProtocolV1ClassTable.INSTANCE);
+        marshallingConfiguration.setObjectTable(ProtocolV1ObjectTable.INSTANCE);
+        marshallingConfiguration.setClassResolver(TCCLClassResolver.INSTANCE);
+
+        return marshallerFactory.createUnmarshaller(marshallingConfiguration);
+    }
+
+    /**
+     * A {@link org.jboss.marshalling.ClassResolver} which returns the context classloader associated
+     * with the thread, when the {@link #getClassLoader()} is invoked
+     */
+    private static final class TCCLClassResolver extends AbstractClassResolver {
+        static TCCLClassResolver INSTANCE = new TCCLClassResolver();
+
+        private TCCLClassResolver() {
+        }
+
+        @Override
+        protected ClassLoader getClassLoader() {
+            return Thread.currentThread().getContextClassLoader();
+        }
+    }
+}

--- a/src/test/java/org/jboss/naming/remote/common/ejb/EchoBean.java
+++ b/src/test/java/org/jboss/naming/remote/common/ejb/EchoBean.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.naming.remote.common.ejb;
+
+import org.jboss.logging.Logger;
+
+/**
+ * User: jpai
+ */
+public class EchoBean implements EchoRemote {
+
+    private static final Logger logger = Logger.getLogger(EchoBean.class);
+
+    @Override
+    public String echo(String msg) {
+        logger.info(this.getClass().getSimpleName() + " echoing message " + msg);
+        return msg;
+    }
+}

--- a/src/test/java/org/jboss/naming/remote/common/ejb/EchoRemote.java
+++ b/src/test/java/org/jboss/naming/remote/common/ejb/EchoRemote.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.naming.remote.common.ejb;
+
+/**
+ * User: jpai
+ */
+public interface EchoRemote {
+
+    String echo(String msg);
+}

--- a/src/test/java/org/jboss/naming/remote/common/ejb/MethodInvocationRequest.java
+++ b/src/test/java/org/jboss/naming/remote/common/ejb/MethodInvocationRequest.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.naming.remote.common.ejb;
+
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
+ */
+public class MethodInvocationRequest {
+
+    private final short invocationId;
+    private final String appName;
+    private final String moduleName;
+    private final String beanName;
+    private final String viewClassName;
+    private final String methodName;
+    private final String[] paramTypes;
+    private final Object[] params;
+    private final String distinctName;
+    private final Map<String, Object> attachments;
+
+    public MethodInvocationRequest(final short invocationId, final String appName, final String moduleName,
+                                   final String distinctName, final String beanName, final String viewClassName,
+                                   final String methodName, final String[] methodParamTypes,
+                                   final Object[] methodParams, final Map<String, Object> attachments) {
+
+        this.invocationId = invocationId;
+        this.appName = appName;
+        this.moduleName = moduleName;
+        this.beanName = beanName;
+        this.viewClassName = viewClassName;
+        this.methodName = methodName;
+        this.params = methodParams;
+        this.attachments = attachments;
+        this.paramTypes = methodParamTypes;
+        this.distinctName = distinctName;
+
+    }
+
+    public short getInvocationId() {
+        return invocationId;
+    }
+
+    public String getMethodName() {
+        return methodName;
+    }
+
+    public String getViewClassName() {
+        return this.viewClassName;
+    }
+
+    public Object[] getParams() {
+        return params;
+    }
+
+    public String[] getParamTypes() {
+        return this.paramTypes;
+    }
+
+    public Map<String, Object> getAttachments() {
+        return attachments;
+    }
+
+    public String getAppName() {
+        return this.appName;
+    }
+
+    public String getModuleName() {
+        return this.moduleName;
+    }
+
+    public String getBeanName() {
+        return this.beanName;
+    }
+
+    public String getDistinctName() {
+        return this.distinctName;
+    }
+
+}

--- a/src/test/java/org/jboss/naming/remote/ejb/EJBInvocationTestCase.java
+++ b/src/test/java/org/jboss/naming/remote/ejb/EJBInvocationTestCase.java
@@ -1,0 +1,178 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.naming.remote.ejb;
+
+import org.jboss.ejb.client.EJBClient;
+import org.jboss.ejb.client.StatelessEJBLocator;
+import org.jboss.logging.Logger;
+import org.jboss.naming.remote.MockContext;
+import org.jboss.naming.remote.TestUtils;
+import org.jboss.naming.remote.common.ejb.DummyEJBServer;
+import org.jboss.naming.remote.common.ejb.EchoBean;
+import org.jboss.naming.remote.common.ejb.EchoRemote;
+import org.jboss.naming.remote.server.RemoteNamingService;
+import org.jboss.remoting3.Endpoint;
+import org.jboss.remoting3.Remoting;
+import org.jboss.remoting3.remote.RemoteConnectionProviderFactory;
+import org.jboss.remoting3.spi.NetworkServerProvider;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.xnio.OptionMap;
+import org.xnio.Xnio;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.Properties;
+import java.util.concurrent.Executors;
+
+/**
+ * Tests that invocations on EJB proxies via remote naming lookup works as expected
+ *
+ * @author Jaikiran Pai
+ */
+public class EJBInvocationTestCase {
+
+    private static final Logger logger = Logger.getLogger(EJBInvocationTestCase.class);
+
+    private static RemoteNamingService server;
+    private static DummyEJBServer dummyEJBServer;
+
+    private static final Context localContext = new MockContext();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        final Xnio xnio = Xnio.getInstance();
+        final Endpoint endpoint = Remoting.createEndpoint("RemoteNaming", xnio, OptionMap.EMPTY);
+        endpoint.addConnectionProvider("remote", new RemoteConnectionProviderFactory(), OptionMap.EMPTY);
+
+        final NetworkServerProvider nsp = endpoint.getConnectionProviderInterface("remote", NetworkServerProvider.class);
+        final SocketAddress bindAddress = new InetSocketAddress("localhost", 7999);
+        final OptionMap serverOptions = TestUtils.createOptionMap();
+
+        nsp.createServer(bindAddress, serverOptions, new TestUtils.DefaultAuthenticationHandler(), null);
+        server = new RemoteNamingService(localContext, Executors.newFixedThreadPool(10));
+        server.start(endpoint);
+
+        // register the EJB server
+        dummyEJBServer = new DummyEJBServer(endpoint);
+        dummyEJBServer.start();
+
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        dummyEJBServer.stop();
+        server.stop();
+    }
+
+    @Before
+    public void beforeTest() {
+        dummyEJBServer.register("my-app", "my-module", "", EchoBean.class.getSimpleName(), new EchoBean());
+    }
+
+    @After
+    public void afterTest() {
+        dummyEJBServer.unregister("my-app", "my-module", "", EchoBean.class.getSimpleName());
+    }
+
+    /**
+     * Tests that a remote naming context created by using <code>jboss.naming.ejb.context=true</code> can be used
+     * to do EJB lookup and invocations.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testEJBInvocation() throws Exception {
+        final StatelessEJBLocator<EchoRemote> statelessEJBLocator = new StatelessEJBLocator<EchoRemote>(EchoRemote.class, "my-app", "my-module", EchoBean.class.getSimpleName(), "");
+        final EchoRemote bean = EJBClient.createProxy(statelessEJBLocator);
+        final String jndiName = "ejb-invocation-test";
+        localContext.bind(jndiName, bean);
+
+        final Properties env = new Properties();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, org.jboss.naming.remote.client.InitialContextFactory.class.getName());
+        env.put(Context.PROVIDER_URL, "remote://localhost:7999");
+        env.put("jboss.naming.client.ejb.context", true);
+        final Context context = new InitialContext(env);
+
+        try {
+            final Object returnedProxy = context.lookup(jndiName);
+            Assert.assertTrue("Object returned by remote naming lookup: " + returnedProxy + " is not an EJB proxy", EJBClient.isEJBProxy(returnedProxy));
+            // make sure the proxy is of the business interface type
+            Assert.assertTrue("EJB proxy returned by remote naming lookup is not of type: " + EchoRemote.class, returnedProxy instanceof EchoRemote);
+            // invoke on the bean proxy
+            final String message = "Gangnam Style!!!";
+            final String echo = ((EchoRemote) returnedProxy).echo(message);
+            Assert.assertEquals("Unexpected echo message from the EJB proxy returned by remote naming lookup", message, echo);
+        } finally {
+            context.close();
+            localContext.unbind(jndiName);
+        }
+    }
+
+
+    /**
+     * Tests that a remote naming context created by using <code>jboss.naming.ejb.context=false</code> fails
+     * when used for EJB invocations
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testEJBInvocationWithoutEJBClientContext() throws Exception {
+        final StatelessEJBLocator<EchoRemote> statelessEJBLocator = new StatelessEJBLocator<EchoRemote>(EchoRemote.class, "my-app", "my-module", EchoBean.class.getSimpleName(), "");
+        final EchoRemote bean = EJBClient.createProxy(statelessEJBLocator);
+        final String jndiName = "ejb-invocation-test-without-ejb-client-context";
+        localContext.bind(jndiName, bean);
+
+
+        final Properties env = new Properties();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, org.jboss.naming.remote.client.InitialContextFactory.class.getName());
+        env.put(Context.PROVIDER_URL, "remote://localhost:7999");
+        env.put("jboss.naming.client.ejb.context", false);
+        final Context context = new InitialContext(env);
+
+        try {
+            final Object returnedProxy = context.lookup(jndiName);
+            Assert.assertTrue("Object returned by remote naming lookup: " + returnedProxy + " is not an EJB proxy", EJBClient.isEJBProxy(returnedProxy));
+            // make sure the proxy is of the business interface type
+            Assert.assertTrue("EJB proxy returned by remote naming lookup is not of type: " + EchoRemote.class, returnedProxy instanceof EchoRemote);
+            // invoke on the bean proxy. MUST fail since the EJB client context isn't setup for this JNDI context
+            final String message = "Gangnam Style!!!";
+            try {
+                final String echo = ((EchoRemote) returnedProxy).echo(message);
+                Assert.fail("Invocation on an EJB proxy without any EJB client context was expected to fail, but it didn't");
+            } catch (IllegalStateException ise) {
+                // expected
+                logger.debug("Got the expected exception while invoking on an EJB proxy without any backing EJB client context", ise);
+            }
+        } finally {
+            context.close();
+            localContext.unbind(jndiName);
+        }
+    }
+}


### PR DESCRIPTION
The commit here changes the way the remote naming project was integrated with the EJB client project to allow for EJB invocations via remote naming contexts. These changes broadly include:

1) Getting rid of the EJB client context selector switching that was being done by the remote naming APIs. Starting with 1.0.13.Final version of EJB client API, we now have a better way of dealing with scoped EJB client contexts. The commit here scopes the EJB client contexts created for remote naming contexts, by using these new APIs.

2) Introduce an EJBClientHandler interface which allows for the remote naming project to function without having a hard dependency on the EJB client project. The EJBClientHandler interface will have no dependency on the EJB client APIs. An implementation of this interface is allowed to have the hard dependency on those APIs. RemoteNamingStoreEJBClientHandler is one such implementation which is plugged into the remote naming context by using reflection. The failure to load such implementation will still allow the remote naming context to function but the EJB invocations via that context will not be functional.

3) The EJBClientHandler will also provide a hook to allow the EJB proxies returned via JNDI lookup to be handled properly before being returned to the client. For example, if a client application creates a remote naming context and asks that context to create a EJB client context too (by passing the jboss.naming.ejb.context=true property), then subsequent lookups of EJB proxies via that remote naming context will be scoped to that EJB client context. This is done by hooking in the EJBClientHandler implementation to process the object returned by the server, before being sent back to the client. The implementation of this interface will then appropriately associate the EJB client context identifier with that returned proxy so that it gets scoped.

4) Other minor changes which includes closing on EJB client context on closing of the remote naming context
