### PR TITLE
[WFLY-3201][bz-1069591] log handleEnd - Channel end notification receive...

### DIFF
--- a/src/main/java/org/jboss/naming/remote/protocol/v1/RemoteNamingStoreV1.java
+++ b/src/main/java/org/jboss/naming/remote/protocol/v1/RemoteNamingStoreV1.java
@@ -259,7 +259,8 @@ public class RemoteNamingStoreV1 implements RemoteNamingStore {
         }
 
         public void handleEnd(final Channel channel) {
-            log.errorf("Channel end notification received, closing channel %s", channel);
+            // WFLY-3201 - log at debug since this is not an error
+            log.debugf("Channel end notification received, closing channel %s", channel);
             try {
                 channel.close();
             } catch (IOException ignore) {


### PR DESCRIPTION
...d, closing channel - at debug

1.0:
https://bugzilla.redhat.com/show_bug.cgi?id=1069591

master:
https://issues.jboss.org/browse/WFLY-3201
https://github.com/jbossas/jboss-remote-naming/pull/18
