### PR TITLE
[WFLY-3201] closing channel is normal exit. should be logged debug

### DIFF
--- a/src/main/java/org/jboss/naming/remote/server/DefaultRemoteNamingServerLogger.java
+++ b/src/main/java/org/jboss/naming/remote/server/DefaultRemoteNamingServerLogger.java
@@ -28,7 +28,7 @@ public class DefaultRemoteNamingServerLogger implements RemoteNamingServerLogger
     }
 
     public void closingChannelOnChannelEnd(final Channel channel) {
-        log.errorf("Channel end notification received, closing channel %s", channel);
+        log.debugf("Channel end notification received, closing channel %s", channel);
     }
 
     public void unnexpectedError(final Throwable t) {


### PR DESCRIPTION
https://github.com/jbossas/jboss-remote-naming/pull/18

Above pull request fix not enough.
In addition, should fix DefaultRemoteNamingServerLogger.closingChannelOnChannelEnd(final Channel channel).
