### PR TITLE
[BZ1278606] Remote Naming holding cache lock while closing leading to…

### DIFF
--- a/src/main/java/org/jboss/naming/remote/client/EndpointCache.java
+++ b/src/main/java/org/jboss/naming/remote/client/EndpointCache.java
@@ -56,29 +56,38 @@ public class EndpointCache {
         return cacheEntry.endpointWrapper;
     }
 
-    public synchronized void release(final CacheKey endpointHash, final boolean async) {
-        final CacheEntry cacheEntry = cache.get(endpointHash);
-        if (cacheEntry.referenceCount.decrementAndGet() == 0) {
-            try {
-                if (async) {
-                    cacheEntry.endpoint.closeAsync();
-                } else {
-                    try {
-                        cacheEntry.endpoint.close();
-                    } catch (IOException e) {
-                        throw new RuntimeException("Failed to close endpoint", e);
-                    }
-                }
-
-            } finally {
-                cache.remove(endpointHash);
+    public void release(final CacheKey endpointHash, final boolean async) {
+        Endpoint toClose;
+        synchronized (this) {
+            final CacheEntry cacheEntry = cache.get(endpointHash);
+            if (cacheEntry.referenceCount.decrementAndGet() == 0) {
+            	try {
+            		toClose = cacheEntry.endpoint;
+            	} finally {
+            		cache.remove(endpointHash);
+            	}
+            } else {
+            	return;
             }
+        }
+        if (async) {
+        	toClose.closeAsync();
+        } else {
+        	try {
+        		toClose.close();
+        	} catch (IOException e) {
+        		throw new RuntimeException("Failed to close endpoint", e);
+        	}
         }
     }
 
-    public synchronized void shutdown() {
-        for(Map.Entry<CacheKey, CacheEntry> entry : cache.entrySet()) {
-            safeClose(entry.getValue().endpoint);
+    public void shutdown() {
+        final CacheEntry[] cacheEntries;
+        synchronized (this) {
+            cacheEntries = cache.values().toArray(new CacheEntry[cache.size()]);
+        }
+        for (CacheEntry entry : cacheEntries) {
+            safeClose(entry.endpoint);
         }
     }
 


### PR DESCRIPTION
… thread pile up

[GSS01531569] after a high cpu load, jms processing comes to a stop - threads stay blocked infinite
BZ 6.4.x : https://bugzilla.redhat.com/show_bug.cgi?id=1278606
PR 6.4.z : https://github.com/jbossas/jboss-remote-naming/pull/26