### PR TITLE
JBNAME-63 Fix type check in Protocol#RENAME

### DIFF
--- a/src/main/java/org/jboss/naming/remote/protocol/v1/Protocol.java
+++ b/src/main/java/org/jboss/naming/remote/protocol/v1/Protocol.java
@@ -677,7 +677,7 @@ class Protocol {
 
     static ProtocolCommand<Void> RENAME = new BaseProtocolCommand<Void, ProtocolIoFuture<Void>>((byte) 0x07) {
         public Void execute(final Channel channel, final Object... args) throws IOException, NamingException {
-            if (args.length != 2 || !(args[0] instanceof Name) || !(args[0] instanceof Name)) {
+            if (args.length != 2 || !(args[0] instanceof Name) || !(args[1] instanceof Name)) {
                 throw new IllegalArgumentException("Rename requires two name arguments");
             }
             final Name name = Name.class.cast(args[0]);


### PR DESCRIPTION
Protocol#RENAME checks the type of the same array element twice before
casting instead of checking the types of all array elements before
casing.

 * fix type check in Protocol#RENAME

Issue: JBNAME-63
https://issues.jboss.org/browse/JBNAME-63